### PR TITLE
docs: Remove README comment about rand-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 URL and cookie safe UIDs
 
 Create cryptographically secure UIDs safe for both cookie and URL usage.
-This is in contrast to modules such as [rand-token](https://www.npmjs.com/package/rand-token)
-and [uid2](https://www.npmjs.com/package/uid2) whose UIDs are actually skewed
-due to the use of `%` and unnecessarily truncate the UID.
-Use this if you could still use UIDs with `-` and `_` in them.
+This is in contrast to modules such as [uid2](https://www.npmjs.com/package/uid2)
+whose UIDs are actually skewed due to the use of `%` and unnecessarily
+truncate the UID. Use this if you could still use UIDs with `-` and `_` in
+them.
 
 ## Installation
 


### PR DESCRIPTION
This PR removes the comment regarding rand-token from the README. The modula (%) usage by rand-token is (and always has been since the first version) done after discarding values that would skew the result. See [here](https://github.com/sehrope/node-rand-token/blob/ad9a571b0ca4bbf5d415a104802d4366fe9caf1d/index.js#L90-L100) for details.